### PR TITLE
Add host to configuration, not just port

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -8,6 +8,7 @@
       "setPostingAccountAuth": false
     }
   ],
+  "httpHost": "localhost",
   "httpPort": 8880,
   "rpc": [
     "https://api.hive.blog",

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ npm install
       "setPostingAccountAuth": false
     }
   ],
+  "httpHost": "localhost",
   "httpPort": 8880,
   "rpc": [
     "https://api.hive.blog",

--- a/server.js
+++ b/server.js
@@ -9,14 +9,25 @@ var app = express();
 
 let client = new dhive.Client(config.rpc);
 
+let listenOptions = {
+  port: config.httpPort ?? 8880,
+  host: config.httpHost ?? "0.0.0.0"
+};
+
+if (config.httpHost === undefined) {
+  signale.warn("httpHost not configured; listening on public IP!");
+}
+
+let listenURI = `http://${listenOptions.host}:${listenOptions.port}`;
+
 app.use(cors());
 app.use(bodyParser.json());
 
 app.use("/api", require("./api"));
 
-app.listen(config.httpPort, function () {
+app.listen(listenOptions, function () {
   signale.star(
-    "#### Creator-API web server listening on " + config.httpPort + " ####"
+    `#### Creator-API web server listening on ${listenURI} ####`
   );
 });
 


### PR DESCRIPTION
For services hosted behind a reverse proxy on the same machine, it's usually desirable to limit the actual web service to the loopback interface only, leaving the listening port unexposed to the outside world. This change makes that possible, while also not breaking existing deployments. They will, however, see a warning in the logs when the service starts up.